### PR TITLE
(ux) Footer: Input button disabled when blur on empty input

### DIFF
--- a/public/js/chat/listeners/messageInputListeners.js
+++ b/public/js/chat/listeners/messageInputListeners.js
@@ -19,6 +19,7 @@ export class MessageInputListeners {
             if (document.getElementById('msg').value !== "") {
                 return setButtonState(messageBtnId, messageBtnSend, [messageBtnDefault, messageBtnOk], false);
             }
+            setButtonState(messageBtnId, messageBtnSend, [messageBtnDefault, messageBtnOk], true);
         });
     };
 


### PR DESCRIPTION
Fixes a regression that occurred. Input button should disable on blur if messageInput field is empty.